### PR TITLE
updated to use gulp-ruby-sass v1.0.0-alpha

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -36,8 +36,7 @@ var bundler = {
 };
 
 gulp.task('styles', function() {
-  return gulp.src('app/styles/main.scss')
-    .pipe($.rubySass({
+  return $.rubySass('app/styles/main.scss', {
       style: 'expanded',
       precision: 10,
       loadPath: ['app/bower_components']

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -15,7 +15,7 @@
     "gulp-jest": "^0.3.0",<% } %>
     "gulp-load-plugins": "^0.8.0",
     "gulp-minify-css": "^0.4.5",
-    "gulp-ruby-sass": "^0.7.1",
+    "gulp-ruby-sass": "^1.0.0-alpha",
     "gulp-size": "^1.2.0",
     "gulp-sync": "^0.1.4",
     "gulp-useref": "^1.1.1",


### PR DESCRIPTION
updated to use gulp-ruby-sass v1.0.0-alpha since v < 1 are not longer supported
